### PR TITLE
POC fix for audioContext issue

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -72,6 +72,17 @@ strong {
   text-align: center;
 }
 
+#enable-audio {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 1.25rem 2rem 1rem;
+  background: none;
+  border: 4px solid #3C3C3C;
+  font-family: 'Pier';
+}
+
 .header-container {
   display: none;
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 </head>
 <body>
   <canvas id="canvas"></canvas>
+  <button id="enable-audio" type="button">Enable Audio</button>
   <div id="hero-card" class="disable-pointer">
     <div class="header-container">
       <div class="header">audiograph</div>

--- a/index.js
+++ b/index.js
@@ -81,7 +81,11 @@ window.onkeydown = function (e) {
 setupPost();
 
 const supportsMedia = !isIOS;
-setupScene({ palettes: getPalette(), supportsMedia });
+const enableAudioButton = document.getElementById('enable-audio');
+enableAudioButton.onclick = () => {
+  setupScene({ palettes: getPalette(), supportsMedia });
+  enableAudioButton.style.display = 'none';
+};
 
 function setupPost () {
   composer.addPass(new EffectComposer.RenderPass(scene, camera));
@@ -189,14 +193,14 @@ function setupScene ({ palettes, envMap }) {
     geo.nextGeometry();
   }, 400);
 
-  // if (isMobile) {
+  if (isMobile) {
     audio.skip();
-  // } else {
-  //   audio.queue();
-  //   audio.once('ready', () => {
-  //     audio.playQueued();
-  //   });
-  // }
+  } else {
+    audio.queue();
+    audio.once('ready', () => {
+      audio.playQueued();
+    });
+  }
 
   const randomPaletteInterval = () => {
     hasNextPalette = false;

--- a/lib/intro.js
+++ b/lib/intro.js
@@ -22,11 +22,11 @@ module.exports = function (opt = {}, cb = noop) {
 
   let delayedReleaseSpacebar = null;
 
-  const introHint = intro1a;
-  // if (isMobile) {
+  const introHint = isMobile ? intro1a : intro1b;
+  if (isMobile) {
     intro2.innerHTML = '<span class="spacebar">tap</span> and hold to load a new track';
     intro3.innerHTML = 'Release <span class="spacebar">tap</span> to play';
-  // }
+  }
 
   const introDelay = 0.0;
   animateIn(header, {


### PR DESCRIPTION
This is a quick hack, but I wasn't sure if anyone was interested in maintaining this repo anymore. I thought I would create a POC to see if there was interest.

### The Problem

Google implemented a non-standards change to the Web Audio API that required users to interact with a site before allowing audio (of course giving their own sites an exception to this rule). This prevented audiograph.xyz from working as expected because when audio tried to play on load, it gets blocked.

### A Possible Solution

For the POC, I just added a button before the setup script. It looks like Matt may have commented out some code related to playing on desktop, so I uncommented those out (now that the Web Audio API could do its thing).

<img width="1440" alt="Screen Shot 2019-10-01 at 10 21 13 AM" src="https://user-images.githubusercontent.com/16308368/65976817-5f50ab80-e436-11e9-88f5-d045abf70d60.png">

<img width="1440" alt="Screen Shot 2019-10-01 at 10 21 25 AM" src="https://user-images.githubusercontent.com/16308368/65976826-637cc900-e436-11e9-900e-a48b8456b759.png">

Not super elegant, but I made the changes so I could show my friend this incredible project.